### PR TITLE
Allow named pipe as input file

### DIFF
--- a/rankmirrors
+++ b/rankmirrors
@@ -142,7 +142,7 @@ while [[ $1 ]]; do
 			done
 			shift $snum
 		fi
-	elif [[ -f "$1" ]]; then
+	elif [[ -f "$1" || -p "$1" ]]; then
 		FILE="1"
 		IFS=$'\n' linearray=( $(<$1) )
 		[[ $linearray ]] || err "File is empty."

--- a/rankmirrors.sh.in
+++ b/rankmirrors.sh.in
@@ -142,7 +142,7 @@ while [[ $1 ]]; do
 			done
 			shift $snum
 		fi
-	elif [[ -f "$1" ]]; then
+	elif [[ -f "$1" || -p "$1" ]]; then
 		FILE="1"
 		IFS=$'\n' linearray=( $(<$1) )
 		[[ $linearray ]] || err "File is empty."


### PR DESCRIPTION
This allows the user to run
rankmirrors <(sed 's/^#//' /etc/pacman.d/mirrorlist.pacnew) > mirrors
